### PR TITLE
Always stick footer to the bottom of the page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,12 @@ body {
   overflow-x: hidden;
 }
 
+#root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
 .heading {
   text-align: center;
   font-size: 2.75rem;
@@ -22,6 +28,7 @@ body {
 }
 
 .form-section {
+  flex: 1;
   min-height: 77.8vh;
   display: grid;
   place-content: center;


### PR DESCRIPTION
This will always push the footer to the bottom of the page by making the form-section element stretch.