### PR TITLE
feat(og-meta-tags): add open graph meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,14 +1,56 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/anmol.ico" />
+
+    <!-- HTML Meta Tags -->
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+
+    <title>Annoying Submit Button</title>
     <meta
       name="description"
       content="Annoying Submit Button using React by Anmol Agarwal"
     />
+
+    <!-- Facebook Meta Tags -->
+    <meta
+      property="og:url"
+      content="https://annoyingsubmitbutton.netlify.app/"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Annoying Submit Button" />
+    <meta
+      property="og:description"
+      content="Annoying Submit Button using React by Anmol Agarwal"
+    />
+    <meta
+      property="og:image"
+      content="https://camo.githubusercontent.com/8e6da2fe472e590760240b6d60efaca857d163abfd9e598daa5db5ad035d6b5a/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f6a34413170756f47307355784f42357242352f67697068792e676966"
+    />
+
+    <!-- Twitter Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      property="twitter:domain"
+      content="annoyingsubmitbutton.netlify.app"
+    />
+    <meta
+      property="twitter:url"
+      content="https://annoyingsubmitbutton.netlify.app/"
+    />
+    <meta name="twitter:title" content="Annoying Submit Button" />
+    <meta
+      name="twitter:description"
+      content="Annoying Submit Button using React by Anmol Agarwal"
+    />
+    <meta
+      name="twitter:image"
+      content="https://camo.githubusercontent.com/8e6da2fe472e590760240b6d60efaca857d163abfd9e598daa5db5ad035d6b5a/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f6a34413170756f47307355784f42357242352f67697068792e676966"
+    />
+
+    <!-- Resources -->
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/anmol.ico" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -20,7 +62,6 @@
       rel="stylesheet"
     />
     <link href="https://emoji-css.afeld.me/emoji.css" rel="stylesheet" />
-    <title>Annoying Submit Button</title>
   </head>
   <script
     src="https://kit.fontawesome.com/d9f7ec7b29.js"


### PR DESCRIPTION
Adding meta tags so we can have more information when linking the page.

![image](https://user-images.githubusercontent.com/43689101/196840719-816ec94e-c7a5-46bc-9b70-5292d75d184f.png)

Signed-off-by: Daniel Boll <danielboll.academico@gmail.com>