### PR TITLE
Disabled footer for smaller devices

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,9 +4,11 @@ import React, { useEffect, useState } from 'react'
 import './App.css'
 import Footer from './components/Footer'
 import ThemeButton from './components/ThemeButton'
+import useWindowDimensions from './custom-hooks/useWindowDimensions'
 
 function App() {
   const minPasswordLength = 6
+  const { height } = useWindowDimensions()
 
   const [form, setForm] = useState({
     email: '',
@@ -193,7 +195,7 @@ function App() {
           </div>
         </form>
       </section>
-      <Footer theme={themeState} />
+      {height < 680 ? null : <Footer theme={themeState} />}
     </>
   )
 }

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -1,13 +1,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@500&display=swap");
 
 footer {
-  width: 100vw;
-  padding: 6.5vh 2vh 1vh 2vh;
-  position: absolute;
-  bottom: 0;
-  max-height: 25vh;
-  min-height: 220px;
-  overflow-y: hidden;
+  padding: 25px;
 }
 
 .footer-content {
@@ -16,6 +10,7 @@ footer {
   align-items: center;
   flex-direction: column;
 }
+
 
 .glitch {
   font-family: "Montserrat", sans-serif;
@@ -32,6 +27,7 @@ footer {
     font-size: 36px;
   }
 }
+
 
 .glitch::before,
 .glitch::after {

--- a/src/custom-hooks/useWindowDimensions.js
+++ b/src/custom-hooks/useWindowDimensions.js
@@ -1,0 +1,26 @@
+import {useState, useEffect} from 'react';
+
+function getWindowDimensions() {
+  const {innerWidth: width, innerHeight: height} = window;
+  return {
+    width,
+    height,
+  };
+}
+
+export default function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  );
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowDimensions;
+}

--- a/src/custom-hooks/useWindowDimensions.js
+++ b/src/custom-hooks/useWindowDimensions.js
@@ -1,8 +1,8 @@
-import {useState, useEffect} from 'react'
+import { useState, useEffect } from 'react'
 
 function getWindowDimensions() {
-  const {innerWidth: width, innerHeight: height} = window
-  return {width, height}
+  const { innerWidth: width, innerHeight: height } = window
+  return { width, height }
 }
 
 export default function useWindowDimensions() {

--- a/src/custom-hooks/useWindowDimensions.js
+++ b/src/custom-hooks/useWindowDimensions.js
@@ -1,26 +1,23 @@
-import {useState, useEffect} from 'react';
+import { useState, useEffect } from 'react'
 
 function getWindowDimensions() {
-  const {innerWidth: width, innerHeight: height} = window;
-  return {
-    width,
-    height,
-  };
+  const { innerWidth: width, innerHeight: height } = window
+  return { width, height }
 }
 
 export default function useWindowDimensions() {
   const [windowDimensions, setWindowDimensions] = useState(
-    getWindowDimensions()
-  );
+    getWindowDimensions(),
+  )
 
   useEffect(() => {
     function handleResize() {
-      setWindowDimensions(getWindowDimensions());
+      setWindowDimensions(getWindowDimensions())
     }
 
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
 
-  return windowDimensions;
+  return windowDimensions
 }

--- a/src/custom-hooks/useWindowDimensions.js
+++ b/src/custom-hooks/useWindowDimensions.js
@@ -12,7 +12,6 @@ export default function useWindowDimensions() {
     function handleResize() {
       setWindowDimensions(getWindowDimensions())
     }
-
     window.addEventListener('resize', handleResize)
     return () => window.removeEventListener('resize', handleResize)
   }, [])

--- a/src/custom-hooks/useWindowDimensions.js
+++ b/src/custom-hooks/useWindowDimensions.js
@@ -6,9 +6,7 @@ function getWindowDimensions() {
 }
 
 export default function useWindowDimensions() {
-  const [windowDimensions, setWindowDimensions] = useState(
-    getWindowDimensions(),
-  )
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions())
 
   useEffect(() => {
     function handleResize() {

--- a/src/custom-hooks/useWindowDimensions.js
+++ b/src/custom-hooks/useWindowDimensions.js
@@ -1,12 +1,14 @@
-import { useState, useEffect } from 'react'
+import {useState, useEffect} from 'react'
 
 function getWindowDimensions() {
-  const { innerWidth: width, innerHeight: height } = window
-  return { width, height }
+  const {innerWidth: width, innerHeight: height} = window
+  return {width, height}
 }
 
 export default function useWindowDimensions() {
-  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions())
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  )
 
   useEffect(() => {
     function handleResize() {


### PR DESCRIPTION
- fixed absolute positioning of footer
- made footer disappear for devices having height less than 680px as either it cant be seen properly or goes over the warning message 