### PR TITLE
ci: add Dependabot, CI validation, and harden npm publish

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: npm
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build library
+        run: npm run build:lib
+
+      - name: Test
+        run: CI=true npm test -- --watchAll=false --passWithNoTests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: npm
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,28 +3,56 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
-# Skip if this is the version-bump commit we push at the end of a release.
-# [skip ci] in the commit message tells GitHub Actions not to run.
-# The 'if' below is a belt-and-suspenders guard in case [skip ci] is ignored.
 jobs:
-  release:
+  validate:
     runs-on: ubuntu-latest
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):')
 
     permissions:
-      contents: write   # push the release commit + tag
-      id-token: write   # required for registry-url token injection
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build library
+        run: npm run build:lib
+
+      - name: Test
+        run: CI=true npm test -- --watchAll=false --passWithNoTests
+
+  release:
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):')
+
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # need full history to read commits since last tag
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Configure git
         run: |
@@ -47,7 +75,6 @@ jobs:
           echo "Commits since last tag:"
           echo "$COMMITS"
 
-          # Breaking change → major, feat → minor, everything else → patch
           BUMP="patch"
           if echo "$COMMITS" | grep -qE "^.+(\(.+\))?!:|BREAKING[- ]CHANGE"; then
             BUMP="major"
@@ -55,21 +82,30 @@ jobs:
             BUMP="minor"
           fi
 
-          echo "bump=$BUMP" >> $GITHUB_OUTPUT
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
           echo "Version bump: $BUMP"
 
       - name: Bump version
         id: version
         run: |
-          NEW_VER=$(npm version ${{ steps.bump.outputs.bump }} --no-git-tag-version)
-          echo "new_version=${NEW_VER}" >> $GITHUB_OUTPUT
+          NEW_VER=$(npm version "${{ steps.bump.outputs.bump }}" --no-git-tag-version)
+          echo "new_version=${NEW_VER}" >> "$GITHUB_OUTPUT"
           echo "New version: $NEW_VER"
 
       - name: Build
         run: npm run build:lib
 
+      - name: Verify npm authentication
+        run: |
+          set -euo pipefail
+          echo "Authenticated as: $(npm whoami)"
+          PKG="$(npm pkg get name | tr -d '"')"
+          npm view "$PKG" version || echo "First publish for $PKG"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -77,5 +113,5 @@ jobs:
         run: |
           git add package.json
           git commit -m "chore(release): ${{ steps.version.outputs.new_version }} [skip ci]"
-          git tag ${{ steps.version.outputs.new_version }}
+          git tag "${{ steps.version.outputs.new_version }}"
           git push origin main --follow-tags

--- a/package.json
+++ b/package.json
@@ -54,11 +54,9 @@
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },
-  "dependencies": {
-    "react-scripts": "^5.0.1",
-    "web-vitals": "^2.1.4"
-  },
   "devDependencies": {
+    "react-scripts": "^5.0.1",
+    "web-vitals": "^2.1.4",
     "@babel/core": "^7.26.0",
     "@babel/preset-react": "^7.26.3",
     "@rollup/plugin-babel": "^6.0.4",


### PR DESCRIPTION
## Summary
- Adds Dependabot for weekly minor/patch dependency and GitHub Actions updates
- Adds CI workflow (lint/build/test or smoke tests) on PRs and pushes to main
- Hardens Release workflow: validation gate, npm auth check, `--ignore-scripts` publish
- Moves build tooling to devDependencies in library packages

## Test plan
- [ ] CI workflow passes on this PR
- [ ] Release workflow publishes on merge to main