### PR TITLE
ci: run Dependabot auto-merge after CI completes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,6 +3,10 @@ name: Dependabot auto-merge
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
 
 permissions:
   contents: write
@@ -11,23 +15,51 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request')
     steps:
+      - name: Resolve pull request
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let pr;
+            if (context.eventName === 'pull_request') {
+              pr = context.payload.pull_request;
+            } else {
+              const { data: pulls } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:${context.payload.workflow_run.head_branch}`,
+                state: 'open',
+              });
+              if (!pulls.length) {
+                core.info('No open PR for completed CI run — skipping.');
+                return;
+              }
+              pr = pulls[0];
+            }
+            if (pr.user.login !== 'dependabot[bot]') {
+              core.info('Not a Dependabot PR — skipping.');
+              return;
+            }
+            core.setOutput('number', String(pr.number));
+            core.setOutput('url', pr.html_url);
+
       - name: Dependabot metadata
+        if: steps.pr.outputs.number != ''
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Skip major semver updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
-        run: echo "Major update — leaving open for manual review."
+          pull-request-number: ${{ steps.pr.outputs.number }}
 
       - name: Approve and auto-merge
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: steps.pr.outputs.number != '' && steps.metadata.outputs.update-type != 'version-update:semver-major'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_URL: ${{ steps.pr.outputs.url }}
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Auto-approves and squash-merges Dependabot patch/minor PRs once CI passes.