### PR TITLE
ci: rename workflow display names for clarity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
-name: CI
-
+name: CI · Validate package
 on:
   pull_request:
   push:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,11 +1,10 @@
-name: Dependabot auto-merge
-
+name: Dependabot · Auto-merge PRs
 on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
   workflow_run:
-    workflows: [CI]
+    workflows: ["CI · Validate package"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,5 +1,4 @@
-name: PR merge hints
-
+name: Comment · PR merge conflict help
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,4 @@
-name: Release
-
+name: Release · Publish to npm
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- Renames GitHub Actions workflow display names to a consistent **Category · Description** pattern
- Makes it easy to scan the Actions tab and know what each workflow does

## Naming scheme
| Category | Workflows |
|----------|-----------|
| **Comment** | PR merge conflict help, Star repo reminder |
| **CI** | Validate package / site / scripts |
| **Deploy** | GitHub Pages |
| **Release** | Publish to npm |
| **Dependabot** | Auto-merge PRs |

## Test plan
- [ ] Workflows still trigger on the same events
- [ ] Dependabot auto-merge still waits for `CI · Validate package` (npm repos)